### PR TITLE
feat(fastify): support builtin prefix + doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ You'll need yarn and lerna installed globally:
 
 The easiest way to try this out is to run the standalone server via `brokeneck-fastify`:
 
+> You'll need yarn and lerna installed as global packages: `npm i -g yarn lerna`, as well as [node.js](https://nodejs.org/en/download) of course
+
 - `lerna bootstrap`
 - `lerna run build`
 - `cd packages/brokeneck-fastify`
-- `cp .env.sample .env`
 - configure `.env` based on the authentication provider you want to use
 - `yarn start`
 - browse to [`http://localhost:5001`](http://localhost:5001)

--- a/packages/brokeneck-fastify/package.json
+++ b/packages/brokeneck-fastify/package.json
@@ -13,7 +13,8 @@
     "test": "tap",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "prepare": "node -e \"fs.existsSync('.env') ? '' : fs.writeFileSync('.env', fs.readFileSync('.env.sample'))\""
   },
   "dependencies": {
     "@azure/graph": "^5.0.1",

--- a/packages/brokeneck-html/package.json
+++ b/packages/brokeneck-html/package.json
@@ -13,7 +13,7 @@
     "dev": "yarn start",
     "start": "cross-env PORT=3001 react-scripts start",
     "clean": "rimraf build",
-    "prepare": "yarn build",
+    "prepare": "node -e \"fs.existsSync('.env') ? '' : fs.writeFileSync('.env', fs.readFileSync('.env.sample'))\" && yarn build",
     "prebuild": "yarn clean",
     "build": "cross-env INLINE_RUNTIME_CHUNK=false react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
### What's in there?

#4 

- [x] doc(desktop): README file
- [ ] doc(fastify): README file
- [ ] doc(html): README file
- [ ] doc(react): README file
- [x] feat(fastify): support builtin prefix + doc
- [x] chore: scripts for creating .env files

### How to test?

Run the example:
```shell
cd examples/custom-path
yarn start
```

Then go to http://localhost:4001

### Notes to reviewers

In this _proposal_, I've leveraged fastify builtin `prefix` option when registering the brokeneck plugin.
It completes `ui.basename` and `mercurius.prefix`, which are still usable independently.

To benefit from fastify plugin isolation, I've removed the usage of fastify-plugin in `lib/plugin.js`  and `lib/plugins/ui/index.js`, but *not* in other plugins, because they add decorators which must be globally accessed within the brokeneck plugin context.

I plan to add another example with basename (still a valid approach as Simone used it to integrate in Titus), and to complete my documentation chore.

