### PR TITLE
feat: auth0 group search functionality

### DIFF
--- a/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.js
@@ -37,10 +37,22 @@ function Auth0Provider(options, logger) {
 
       return user
     },
-    async listGroups() {
-      const groups = await auth0.getRoles()
+    async listGroups({ pageNumber, pageSize, search }) {
+      const page = pageNumber ? Number(pageNumber) - 1 : 0
 
-      logger.debug({ groups })
+      const data = await auth0.getRoles({
+        page: page,
+        per_page: pageSize,
+        include_totals: true,
+        name_filter: search || undefined
+      })
+
+      const groups = {
+        data: data.roles,
+        nextPage: data.roles.length === data.limit ? (page + 2).toString() : ''
+      }
+
+      logger.debug({ groups }, 'loaded groups')
 
       return groups
     },

--- a/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.test.js
@@ -36,8 +36,6 @@ tap.test('auth0 provider', async t => {
         search: 'search'
       })
 
-      console.log(result)
-
       t.deepEqual(result, { data: users, nextPage: 2 })
     })
 
@@ -49,8 +47,6 @@ tap.test('auth0 provider', async t => {
         pageSize: 2
       })
 
-      console.log(result)
-
       t.deepEqual(result, { data: users, nextPage: 2 })
     })
 
@@ -61,8 +57,6 @@ tap.test('auth0 provider', async t => {
       const result = await provider.listUsers({
         pageSize: 2
       })
-
-      console.log(result)
 
       t.deepEqual(result, { data: users, nextPage: '' })
     })
@@ -76,8 +70,6 @@ tap.test('auth0 provider', async t => {
         pageSize: 2,
         search: 'search'
       })
-
-      console.log(result)
 
       t.deepEqual(result, { data: users, nextPage: 2 })
     })
@@ -96,13 +88,59 @@ tap.test('auth0 provider', async t => {
     sinon.assert.calledWith(auth0.getUser, sinon.match({ id }))
   })
 
-  t.test('returns groups', async t => {
-    const groups = faker.random.arrayElements()
-    auth0.getRoles = sinon.stub().resolves(groups)
+  t.test('groups', async t => {
+    t.test('no page', async t => {
+      const groups = faker.random.arrayElements()
 
-    const result = await provider.listGroups()
+      auth0.getRoles = sinon
+        .stub()
+        .resolves({ roles: groups, limit: groups.length })
 
-    t.equal(result, groups)
+      const result = await provider.listGroups({
+        pageSize: 2
+      })
+
+      t.deepEqual(result, { data: groups, nextPage: 2 })
+    })
+
+    t.test('no search', async t => {
+      const groups = faker.random.arrayElements()
+      auth0.getGroups = sinon.stub().resolves({ groups })
+
+      const result = await provider.listGroups({
+        pageSize: 2
+      })
+
+      t.deepEqual(result, { data: groups, nextPage: 2 })
+    })
+
+    t.test('pagination', async t => {
+      const groups = faker.random.arrayElements()
+      auth0.getRoles = sinon.stub().resolves({
+        roles: groups,
+        length: groups.length
+      })
+
+      const result = await provider.listGroups({
+        pageSize: 2
+      })
+
+      t.deepEqual(result, { data: groups, nextPage: '' })
+    })
+
+    t.test('page 1', async t => {
+      const groups = faker.random.arrayElements()
+      auth0.getRoles = sinon
+        .stub()
+        .resolves({ roles: groups, limit: groups.length })
+
+      const result = await provider.listGroups({
+        pageNumber: 1,
+        pageSize: 2
+      })
+
+      t.deepEqual(result, { data: groups, nextPage: 2 })
+    })
   })
 
   t.test('returns group', async t => {

--- a/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.test.js
@@ -105,13 +105,13 @@ tap.test('auth0 provider', async t => {
 
     t.test('no search', async t => {
       const groups = faker.random.arrayElements()
-      auth0.getGroups = sinon.stub().resolves({ groups })
+      auth0.getRoles = sinon.stub().resolves({ roles: groups })
 
       const result = await provider.listGroups({
         pageSize: 2
       })
 
-      t.deepEqual(result, { data: groups, nextPage: 2 })
+      t.deepEqual(result, { data: groups, nextPage: '' })
     })
 
     t.test('pagination', async t => {

--- a/packages/brokeneck-fastify/lib/plugins/auth/cognito/provider.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/cognito/provider.js
@@ -37,9 +37,11 @@ function CognitoProvider(options, logger) {
 
       return user
     },
-    async listGroups() {
+    async listGroups({ pageNumber, pageSize, search }) {
       const result = await cognito
         .listGroups({
+          Limit: pageSize,
+          // NextToken:
           UserPoolId
         })
         .promise()

--- a/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.js
@@ -9,8 +9,8 @@ module.exports = function makeResolvers(fastify) {
       user(_, { id }) {
         return fastify.provider.getUser(id)
       },
-      groups() {
-        return fastify.provider.listGroups()
+      groups(_, { pageNumber, pageSize, search }) {
+        return fastify.provider.listGroups({ pageNumber, pageSize, search })
       },
       group(_, { id }) {
         return fastify.provider.getGroup(id)

--- a/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.test.js
@@ -55,7 +55,8 @@ tap.test('resolvers', async t => {
 
       const args = {
         pageNumber: 1,
-        pageSize: 2
+        pageSize: 2,
+        search: 'search'
       }
       const result = await resolvers.Query.groups(null, args)
 

--- a/packages/brokeneck-fastify/lib/plugins/graphql/typeDefs.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/typeDefs.js
@@ -44,10 +44,15 @@ const typeDefs = gql`
     nextPage: String
   }
 
+  type PaginatedGroups {
+    data: [Group]!
+    nextPage: String
+  }
+
   type Query {
     users(pageNumber: String, pageSize: Int, search: String): PaginatedUsers
     user(id: String!): User
-    groups: [Group]
+    groups(pageNumber: String, pageSize: Int, search: String): PaginatedGroups
     group(id: String!): Group
     provider: String!
   }

--- a/packages/brokeneck-fastify/lib/plugins/graphql/typeDefs.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/typeDefs.js
@@ -52,11 +52,7 @@ const typeDefs = gql`
   type Query {
     users(pageNumber: String, pageSize: Int, search: String): PaginatedUsers
     user(id: String!): User
-<<<<<<< HEAD
     groups(pageNumber: String, pageSize: Int, search: String): PaginatedGroups
-=======
-    groups(pageNumber: String, pageSize: Int): PaginatedGroups
->>>>>>> master
     group(id: String!): Group
     provider: String!
   }

--- a/packages/brokeneck-react/src/components/Groups.js
+++ b/packages/brokeneck-react/src/components/Groups.js
@@ -1,108 +1,182 @@
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Button,
   CircularProgress,
   IconButton,
+  InputAdornment,
   Link,
+  makeStyles,
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
+  TextField,
   Typography
 } from '@material-ui/core'
-import React from 'react'
 import { Link as RouterLink, useRouteMatch } from 'react-router-dom'
 import { useQuery } from 'graphql-hooks'
 import startCase from 'lodash.startcase'
+import debounce from 'lodash.debounce'
 
 import useCreateGroupDialog from '../hooks/useCreateGroupDialog'
-import { LOAD_GROUPS } from '../graphql'
 import useFields from '../hooks/useFields'
+import useSurrogatePagination from '../hooks/useSurrogatePagination'
+import { LOAD_GROUPS } from '../graphql'
 
 import Square from './Square'
+
+const useStyles = makeStyles(theme => ({
+  spacing: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > * + *': {
+      marginLeft: theme.spacing(2)
+    }
+  },
+  right: {
+    marginLeft: 'auto'
+  }
+}))
 
 export default function Groups() {
   const match = useRouteMatch()
   const groupFields = useFields('Group')
+  const [search, setSearch] = useState({ immediate: '', debounced: '' })
+  const classes = useStyles()
+
+  const debouncedSetSearch = useMemo(() => debounce(setSearch, 500), [
+    setSearch
+  ])
+
+  useEffect(() => () => debouncedSetSearch.cancel(), [debouncedSetSearch])
+
+  const {
+    pageSize,
+    surrogatePageNumber,
+    useUpdateSurrogatePageNumber,
+    useTablePagination
+  } = useSurrogatePagination({ pageSizeOptions: [2, 3, 4] }) // TODO: temp small page sizes for testing
+
   const { data, loading, refetch: loadGroups } = useQuery(
-    LOAD_GROUPS(groupFields.all)
+    LOAD_GROUPS(groupFields.all),
+    {
+      variables: {
+        pageNumber: surrogatePageNumber,
+        pageSize,
+        search: search.debounced
+      }
+    }
   )
+
+  const handleSearchChange = search => {
+    setSearch(s => ({ ...s, immediate: search }))
+    debouncedSetSearch(s => ({ ...s, debounced: search }))
+  }
+
   const [dialog, openDialog] = useCreateGroupDialog(loadGroups)
+
+  useUpdateSurrogatePageNumber(data?.groups.nextPage)
+
+  const tablePagination = useTablePagination(data?.groups)
+
+  console.log(search)
 
   return (
     <>
       {dialog}
       <Square mb={3}>
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="space-between"
-          mb={3}
-        >
+        <Box className={classes.spacing} mb={3}>
           <Button variant="contained" color="primary" onClick={openDialog}>
             Create Group
           </Button>
-          <IconButton onClick={loadGroups} title="reload groups">
-            <Typography>
-              <span role="img" aria-label="reload groups">
-                🔃
-              </span>
-            </Typography>
-          </IconButton>
+          <TextField
+            label="Search"
+            variant="outlined"
+            size="small"
+            value={search.immediate}
+            onChange={e => handleSearchChange(e.target.value)}
+            InputProps={{
+              endAdornment: search.immediate && (
+                <InputAdornment position="end">
+                  <IconButton onClick={() => handleSearchChange('')}>
+                    <Typography>
+                      <span role="img" aria-label="clear">
+                        ❌
+                      </span>
+                    </Typography>
+                  </IconButton>
+                </InputAdornment>
+              )
+            }}
+          />
+          <div className={classes.right}>
+            <IconButton onClick={loadGroups} title="reload groups">
+              <Typography>
+                <span role="img" aria-label="reload groups">
+                  🔃
+                </span>
+              </Typography>
+            </IconButton>
+          </div>
         </Box>
-        <Table>
-          <TableHead>
-            <TableRow>
-              {groupFields.all.map(field => (
-                <TableCell
-                  align={
-                    groupFields.metadata[field].type === 'checkbox'
-                      ? 'center'
-                      : undefined
-                  }
-                  key={field}
-                >
-                  {startCase(field)}
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {data?.groups.map(group => (
-              <TableRow key={group[groupFields.id]}>
-                {groupFields.all.map((field, index) => (
-                  <TableCell key={field}>
-                    {!index ? (
-                      <Link
-                        color="secondary"
-                        component={RouterLink}
-                        to={`${match.url}/${group[groupFields.id]}`}
-                      >
-                        <Typography>{group[field]}</Typography>
-                      </Link>
-                    ) : groupFields.metadata[field].type === 'checkbox' ? (
-                      <Typography align="center">
-                        <span role="img" aria-label={field}>
-                          {group[field] ? '✅' : '❌'}
-                        </span>
-                      </Typography>
-                    ) : (
-                      <Typography>{group[field]}</Typography>
-                    )}
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                {groupFields.all.map(field => (
+                  <TableCell
+                    align={
+                      groupFields.metadata[field].type === 'checkbox'
+                        ? 'center'
+                        : undefined
+                    }
+                    key={field}
+                  >
+                    {startCase(field)}
                   </TableCell>
                 ))}
               </TableRow>
-            ))}
-            {loading && (
-              <TableRow>
-                <TableCell colSpan={groupFields.all.length}>
-                  <CircularProgress />
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {data?.groups.data.map(group => (
+                <TableRow key={group[groupFields.id]}>
+                  {groupFields.all.map((field, index) => (
+                    <TableCell key={field}>
+                      {!index ? (
+                        <Link
+                          color="secondary"
+                          component={RouterLink}
+                          to={`${match.url}/${group[groupFields.id]}`}
+                        >
+                          <Typography>{group[field]}</Typography>
+                        </Link>
+                      ) : groupFields.metadata[field].type === 'checkbox' ? (
+                        <Typography align="center">
+                          <span role="img" aria-label={field}>
+                            {group[field] ? '✅' : '❌'}
+                          </span>
+                        </Typography>
+                      ) : (
+                        <Typography>{group[field]}</Typography>
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+              {loading && (
+                <TableRow>
+                  <TableCell colSpan={groupFields.all.length}>
+                    <CircularProgress />
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        {tablePagination}
       </Square>
     </>
   )

--- a/packages/brokeneck-react/src/graphql.js
+++ b/packages/brokeneck-react/src/graphql.js
@@ -9,9 +9,13 @@ query LoadGroup($id: String!) {
 }
 `
 
-export const LOAD_GROUPS = fields => `{ 
-  groups { 
-    ${fields.join('\n')} 
+export const LOAD_GROUPS = fields => ` 
+query LoadGroups($pageNumber: String, $pageSize: Int, $search: String) { 
+  groups(pageNumber: $pageNumber, pageSize: $pageSize, search: $search) { 
+    data {
+      ${fields.join('\n')} 
+    }
+    nextPage
   } 
 }`
 


### PR DESCRIPTION
* Added Search for Groups when using Auth0
* Added `pageSize` attribute to AWS ListGroups (filter/search not available and pursuit of alternate solution paused for now)
* Added Search Input to Groups Page

WIP:
* I'd like to atomize components of the pages in brokeneck-react so that we aren't duplicating code