### PR TITLE
feat(capabilities): group search

### DIFF
--- a/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.js
@@ -16,7 +16,12 @@ function Auth0Provider(options, logger) {
   })
 
   return {
-    name: 'auth0',
+    meta: {
+      name: 'auth0',
+      capabilities: {
+        canSearchGroups: true
+      }
+    },
     async listUsers({ pageNumber, pageSize, search }) {
       const page = pageNumber ? Number(pageNumber) - 1 : 0
 

--- a/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/auth0/provider.test.js
@@ -28,8 +28,13 @@ tap.test('auth0 provider', async t => {
     sinon.restore()
   })
 
-  t.test('returns the name', async t => {
-    t.equal(provider.name, 'auth0')
+  t.test('returns the meta', async t => {
+    t.deepEqual(provider.meta, {
+      name: 'auth0',
+      capabilities: {
+        canSearchGroups: true
+      }
+    })
   })
 
   t.test('users', async t => {

--- a/packages/brokeneck-fastify/lib/plugins/auth/azure/provider.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/azure/provider.js
@@ -15,7 +15,12 @@ function AzureProvider(options, credentials, logger) {
   const azure = new GraphRbacManagementClient(credentials, options.tenantId)
 
   return {
-    name: 'azure',
+    meta: {
+      name: 'azure',
+      capabilities: {
+        canSearchGroups: false
+      }
+    },
     async listUsers({ pageNumber, pageSize, search }) {
       const options = { top: pageSize, search: `"displayName:${search}"` }
 

--- a/packages/brokeneck-fastify/lib/plugins/auth/azure/provider.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/azure/provider.test.js
@@ -29,8 +29,13 @@ tap.test('azure provider', async t => {
     sinon.restore()
   })
 
-  t.test('returns the name', async t => {
-    t.equal(provider.name, 'azure')
+  t.test('returns the meta', async t => {
+    t.deepEqual(provider.meta, {
+      name: 'azure',
+      capabilities: {
+        canSearchGroups: false
+      }
+    })
   })
 
   t.test('users', async t => {

--- a/packages/brokeneck-fastify/lib/plugins/auth/cognito/provider.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/cognito/provider.js
@@ -10,7 +10,12 @@ function CognitoProvider(options, logger) {
   const UserPoolId = options.userPoolId
 
   return {
-    name: 'cognito',
+    meta: {
+      name: 'cognito',
+      capabilities: {
+        canSearchGroups: false
+      }
+    },
     async listUsers({ pageNumber, pageSize, search }) {
       const result = await cognito
         .listUsers({

--- a/packages/brokeneck-fastify/lib/plugins/auth/cognito/provider.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/auth/cognito/provider.test.js
@@ -26,8 +26,13 @@ tap.test('cognito provider', async t => {
     sinon.restore()
   })
 
-  t.test('returns the name', async t => {
-    t.equal(provider.name, 'cognito')
+  t.test('returns the meta', async t => {
+    t.deepEqual(provider.meta, {
+      name: 'cognito',
+      capabilities: {
+        canSearchGroups: false
+      }
+    })
   })
 
   t.test('users', async t => {

--- a/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.js
@@ -16,7 +16,7 @@ module.exports = function makeResolvers(fastify) {
         return fastify.provider.getGroup(id)
       },
       provider() {
-        return fastify.provider.name
+        return fastify.provider.meta
       }
     },
     Mutation: {

--- a/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/resolvers.test.js
@@ -78,14 +78,14 @@ tap.test('resolvers', async t => {
       sinon.assert.calledOnceWithMatch(fastify.provider.getGroup, id)
     })
 
-    t.test('name', async t => {
+    t.test('provider', async t => {
       const name = faker.random.word()
 
-      fastify.provider.name = name
+      fastify.provider.meta = { name }
 
       const result = await resolvers.Query.provider()
 
-      t.equal(result, name)
+      t.deepEqual(result, { name })
     })
   })
 

--- a/packages/brokeneck-fastify/lib/plugins/graphql/typeDefs.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/typeDefs.js
@@ -49,12 +49,21 @@ const typeDefs = gql`
     nextPage: String
   }
 
+  type Capabilities {
+    canSearchGroups: Boolean!
+  }
+
+  type Provider {
+    name: String!
+    capabilities: Capabilities!
+  }
+
   type Query {
     users(pageNumber: String, pageSize: Int, search: String): PaginatedUsers
     user(id: String!): User
     groups(pageNumber: String, pageSize: Int, search: String): PaginatedGroups
     group(id: String!): Group
-    provider: String!
+    provider: Provider!
   }
 
   type Mutation {

--- a/packages/brokeneck-html/package.json
+++ b/packages/brokeneck-html/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "prebuild": "yarn clean",
     "build": "cross-env INLINE_RUNTIME_CHUNK=false react-scripts build",
-    "test": "CI=true react-scripts test",
+    "test": "cross-env CI=true react-scripts test",
     "test:dev": "react-scripts test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/brokeneck-react/src/components/Admin.js
+++ b/packages/brokeneck-react/src/components/Admin.js
@@ -3,14 +3,14 @@ import { Switch, Route, Redirect, useLocation } from 'react-router-dom'
 import { Box, CircularProgress, makeStyles } from '@material-ui/core'
 import { useQuery } from 'graphql-hooks'
 
-import { LOAD_SCHEMA } from '../graphql'
+import { LOAD_ROOT } from '../graphql'
 
 import Users from './Users'
 import Groups from './Groups'
 import User from './User'
 import Group from './Group'
 import Navigation from './Navigation'
-import SchemaContext from './SchemaContext'
+import RootContext from './RootContext'
 import Footer from './Footer'
 
 const useGlobalStyles = makeStyles({
@@ -29,16 +29,18 @@ const useGlobalStyles = makeStyles({
 export default function Admin() {
   useGlobalStyles()
   const { pathname } = useLocation()
-  const { data, loading } = useQuery(LOAD_SCHEMA)
+  const { data, loading } = useQuery(LOAD_ROOT)
+
+  console.log(data)
 
   return (
     <Box display="flex" flexDirection="column" flex={1}>
-      <Navigation />
       {loading ? (
         <CircularProgress />
       ) : (
-        <Box mx={2}>
-          <SchemaContext.Provider value={data.__schema}>
+        <RootContext.Provider value={data}>
+          <Navigation />
+          <Box mx={2}>
             <Switch>
               {/* trim trailing slashes */}
               <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
@@ -56,8 +58,8 @@ export default function Admin() {
                 {({ match }) => <Group groupId={match.params.groupId} />}
               </Route>
             </Switch>
-          </SchemaContext.Provider>
-        </Box>
+          </Box>
+        </RootContext.Provider>
       )}
       <Box mt="auto">
         <Footer />

--- a/packages/brokeneck-react/src/components/Groups.js
+++ b/packages/brokeneck-react/src/components/Groups.js
@@ -25,6 +25,7 @@ import useCreateGroupDialog from '../hooks/useCreateGroupDialog'
 import useFields from '../hooks/useFields'
 import useSurrogatePagination from '../hooks/useSurrogatePagination'
 import { LOAD_GROUPS } from '../graphql'
+import useProvider from '../hooks/useProvider'
 
 import Square from './Square'
 
@@ -46,6 +47,9 @@ export default function Groups() {
   const groupFields = useFields('Group')
   const [search, setSearch] = useState({ immediate: '', debounced: '' })
   const classes = useStyles()
+  const {
+    capabilities: { canSearchGroups }
+  } = useProvider()
 
   const debouncedSetSearch = useMemo(() => debounce(setSearch, 500), [
     setSearch
@@ -90,26 +94,28 @@ export default function Groups() {
           <Button variant="contained" color="primary" onClick={openDialog}>
             Create Group
           </Button>
-          <TextField
-            label="Search"
-            variant="outlined"
-            size="small"
-            value={search.immediate}
-            onChange={e => handleSearchChange(e.target.value)}
-            InputProps={{
-              endAdornment: search.immediate && (
-                <InputAdornment position="end">
-                  <IconButton onClick={() => handleSearchChange('')}>
-                    <Typography>
-                      <span role="img" aria-label="clear">
-                        ❌
-                      </span>
-                    </Typography>
-                  </IconButton>
-                </InputAdornment>
-              )
-            }}
-          />
+          {canSearchGroups && (
+            <TextField
+              label="Search"
+              variant="outlined"
+              size="small"
+              value={search.immediate}
+              onChange={e => handleSearchChange(e.target.value)}
+              InputProps={{
+                endAdornment: search.immediate && (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => handleSearchChange('')}>
+                      <Typography>
+                        <span role="img" aria-label="clear">
+                          ❌
+                        </span>
+                      </Typography>
+                    </IconButton>
+                  </InputAdornment>
+                )
+              }}
+            />
+          )}
           <div className={classes.right}>
             <IconButton onClick={loadGroups} title="reload groups">
               <Typography>

--- a/packages/brokeneck-react/src/components/Provider.js
+++ b/packages/brokeneck-react/src/components/Provider.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Chip, makeStyles } from '@material-ui/core'
-import { useQuery } from 'graphql-hooks'
 
-import { LOAD_PROVIDER } from '../graphql'
+import useProvider from '../hooks/useProvider'
 
 const useStyles = makeStyles({
   text: {
@@ -11,12 +10,8 @@ const useStyles = makeStyles({
 })
 
 export default function Provider() {
-  const { data, loading } = useQuery(LOAD_PROVIDER)
+  const provider = useProvider()
   const classes = useStyles()
 
-  if (loading) {
-    return null
-  }
-
-  return <Chip className={classes.text} label={data.provider}></Chip>
+  return <Chip className={classes.text} label={provider.name}></Chip>
 }

--- a/packages/brokeneck-react/src/components/RootContext.js
+++ b/packages/brokeneck-react/src/components/RootContext.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const RootContext = React.createContext()
+
+export default RootContext

--- a/packages/brokeneck-react/src/components/SchemaContext.js
+++ b/packages/brokeneck-react/src/components/SchemaContext.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const SchemaContext = React.createContext()
-
-export default SchemaContext

--- a/packages/brokeneck-react/src/graphql.js
+++ b/packages/brokeneck-react/src/graphql.js
@@ -83,10 +83,14 @@ mutation CreateUser($input: UserInput!) {
 }
 `
 
-export const LOAD_PROVIDER = `{ provider }`
-
-export const LOAD_SCHEMA = `
+export const LOAD_ROOT = `
 {
+  provider {
+    name
+    capabilities {
+      canSearchGroups
+    }
+  }
   __schema {
     types {
       name

--- a/packages/brokeneck-react/src/hooks/useProvider.js
+++ b/packages/brokeneck-react/src/hooks/useProvider.js
@@ -1,0 +1,9 @@
+import { useContext } from 'react'
+
+import RootContext from '../components/RootContext'
+
+export default function useProvider() {
+  const { provider } = useContext(RootContext)
+
+  return provider
+}

--- a/packages/brokeneck-react/src/hooks/useSchema.js
+++ b/packages/brokeneck-react/src/hooks/useSchema.js
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 
-import SchemaContext from '../components/SchemaContext'
+import RootContext from '../components/RootContext'
 
 export default function useSchema(typeName) {
-  const schema = useContext(SchemaContext)
+  const { __schema } = useContext(RootContext)
 
-  return schema.types.find(type => type.name === typeName)
+  return __schema.types.find(type => type.name === typeName)
 }


### PR DESCRIPTION
Closes #19 

Adds capabilities support so we can differentiate between what each provider is capable to do.

This PR implements fundamental support for capabilities and disables searching groups for azure and cognito in the groups page.