### PR TITLE
fix: fix peerDependencies with material ui lab

### DIFF
--- a/packages/brokeneck-react/package.json
+++ b/packages/brokeneck-react/package.json
@@ -24,7 +24,6 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "@material-ui/lab": "^4.0.0-alpha.57",
     "graphql-hooks": "^5.0.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isnil": "^4.0.0",
@@ -35,6 +34,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.11.0",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0"
@@ -48,6 +48,7 @@
     "@babel/preset-react": "^7.12.5",
     "@babel/runtime": "^7.12.5",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",


### PR DESCRIPTION
This is needed by integrations like the one with Titus.

`"@material-ui/lab": "^4.0.0-alpha.57"` will need to be added to titus-frontend when using newer versions of brokeneck-react.