### PR TITLE
test(brokeneck-fastify): switch to response.json, updates the yarn.lock

### DIFF
--- a/packages/brokeneck-fastify/lib/plugins/graphql/index.test.js
+++ b/packages/brokeneck-fastify/lib/plugins/graphql/index.test.js
@@ -53,7 +53,7 @@ tap.test('graphql with mercurius', async t => {
       body: JSON.stringify({ query })
     })
 
-    t.same(JSON.parse(response.body), {
+    t.same(response.json(), {
       data: {
         provider: {
           name: 'test'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9007,15 +9007,10 @@ graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^15.5.1:
+graphql@^15.4.0, graphql@^15.5.1:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
   integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
-
-graphql@^16.0.0:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.1.tgz#93a13cd4e0e38ca8d0832e79614c8578bfd34f10"
-  integrity sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==
 
 gray-matter@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
I missed the last push...