### PR TITLE
Use ajv from dependencies

### DIFF
--- a/packages/brokeneck-fastify/package.json
+++ b/packages/brokeneck-fastify/package.json
@@ -18,9 +18,10 @@
   },
   "dependencies": {
     "@azure/graph": "^5.0.1",
-    "@graphql-tools/schema": "^8.0.0",
     "@azure/ms-rest-nodeauth": "^3.0.6",
+    "@graphql-tools/schema": "^8.0.0",
     "@nearform/brokeneck-html": "^1.0.0-spinal.8",
+    "ajv": "^8.8.2",
     "auth0": "^2.30.0",
     "aws-sdk": "^2.793.0",
     "ejs": "^3.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,7 +4036,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.3, ajv
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.6.3:
+ajv@^8.0.0, ajv@^8.0.1, ajv@^8.6.3, ajv@^8.8.2:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
   integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==


### PR DESCRIPTION
As mentioned by @Eomm, we should use Ajv from the dependencies and not the default fastify one.

> Note that we are using the fastify's ajv dependency (v6 by default).
> 
> We should add `ajv` to the dependancies
> 
> _Originally posted by @Eomm in https://github.com/nearform/brokeneck/pull/189#discussion_r764171579_